### PR TITLE
feat: add field auto-numbering and custom height support

### DIFF
--- a/schemas/ddos-complete.yaml
+++ b/schemas/ddos-complete.yaml
@@ -12,11 +12,9 @@ form:
   author: Robin Mordasiewicz
   description: Complete DDoS Protection requirements assessment form with content
   positioning: flow
+  numbering: true
 
 content:
-  # ===========================================
-  # PAGE 1: DDoS Attack History & ASN Info
-  # ===========================================
   - type: heading
     level: 1
     text: "Network DDoS Protection Questionnaire"
@@ -51,11 +49,22 @@ content:
       - "Annually"
       - "Unkown"
 
+  - type: field
+    label: "Network diagram:"
+    fieldType: dropdown
+    fieldName: diagram_available
+    labelPosition: left
+    labelWidth: 100
+    width: 150
+    options:
+      - "Yes"
+      - "No"
+
   # Simplified table: using fieldPrefix + rowCount
   - type: table
     label: "Recent Attacks"
     fieldPrefix: attack
-    rowCount: 15
+    rowCount: 5
     columns:
       - { label: "Date", width: 70, cellType: text, fieldSuffix: date }
       - label: "Type"
@@ -126,124 +135,187 @@ content:
           - { value: ransom_demand, label: "Ransom Demand" }
           - { value: multi_dimensional, label: "Multi-Dimensional" }
 
-  - type: admonition
-    variant: warning
-    title: "ASN"
-    text: "Without an Autonomous System Number BGP-based DDoS mitigation options limited."
-
-  # Simplified table: using values syntax for label+field rows
   - type: table
     label: "ASN Information"
-    columns:
-      - { label: "ASN Number", width: 200, cellType: text }
-      - label: "Status"
-        width: 200
-        cellType: dropdown
-        options:
-          - { value: yes, label: "Under Active Attack" }
-          - { value: no, label: "No Known Active Attack" }
-    rows:
-      - values: ["asn_number", "active_attack"]
-
-  - type: admonition
-    variant: note
-    title: "BGP Network Prefix"
-    text: "The network prefix size must be a /24 or shorter (/23, /22, /21, etc.)."
-
-  # Simplified table: using fieldPrefix + rowCount
-  - type: table
-    label: "Network Prefixes"
-    fieldPrefix: prefix
+    fieldPrefix: asn
     rowCount: 4
     columns:
-      - { label: "Prefix (CIDR)", width: 150, cellType: text, fieldSuffix: cidr }
-      - { label: "Size", width: 80, cellType: text, fieldSuffix: size }
-      - label: "BGP Announced"
+      - { label: "ASN Number", width: 100, cellType: text, fieldSuffix: number }
+      - label: "Type"
+        width: 80
+        cellType: dropdown
+        fieldSuffix: type
+        options:
+          - { value: public_2byte, label: "Public 2-byte" }
+          - { value: public_4byte, label: "Public 4-byte" }
+          - { value: private, label: "Private" }
+      - label: "Ownership"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: ownership
+        options:
+          - { value: owned, label: "Owned" }
+          - { value: leased, label: "Leased" }
+          - { value: provider, label: "Provider Assigned" }
+      - label: "RPKI ROA"
+        width: 80
+        cellType: dropdown
+        fieldSuffix: rpki
+        options:
+          - { value: deployed, label: "Deployed" }
+          - { value: planned, label: "Planned" }
+          - { value: none, label: "None" }
+      - label: "IRR Status"
+        width: 80
+        cellType: dropdown
+        fieldSuffix: irr
+        options:
+          - { value: current, label: "Current" }
+          - { value: outdated, label: "Outdated" }
+          - { value: none, label: "None" }
+
+  - type: table
+    label: "Primary Upstream Providers"
+    fieldPrefix: upstream
+    rowCount: 4
+    columns:
+      - { label: "Provider Name", width: 150, cellType: text, fieldSuffix: name }
+      - { label: "Provider ASN", width: 100, cellType: text, fieldSuffix: asn }
+      - label: "Connection Type"
         width: 120
         cellType: dropdown
-        fieldSuffix: bgp
+        fieldSuffix: type
+        options:
+          - { value: transit, label: "Transit" }
+          - { value: peering, label: "Peering" }
+          - { value: ix, label: "Internet Exchange" }
+      - label: "BGP Communities"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: communities
         options:
           - { value: yes, label: "Yes" }
           - { value: no, label: "No" }
 
-  - type: field
-    label: "Total Network Prefixes"
-    fieldType: text
-    fieldName: total_prefixes
-    width: 200
-
-  # ===========================================
-  # PAGE 2: Data Centers & Infrastructure
-  # ===========================================
-  - type: heading
-    level: 2
-    text: "Infrastructure Overview"
-
-  - type: heading
-    level: 3
-    text: "Data Centers"
-
-  # Simplified table: using fieldPrefix + rowCount
   - type: table
-    label: "Data Center Inventory"
-    fieldPrefix: dc
-    rowCount: 4
+    label: "Network Prefixes"
+    fieldPrefix: prefix
+    rowCount: 8
     columns:
-      - { label: "Location", width: 150, cellType: text, fieldSuffix: location }
+      - { label: "Prefix (CIDR)", width: 120, cellType: text, fieldSuffix: cidr }
+      - label: "Ownership"
+        width: 90
+        cellType: dropdown
+        fieldSuffix: ownership
+        options:
+          - { value: pi, label: "PI (Independent)" }
+          - { value: pa, label: "PA (Assigned)" }
+          - { value: leased, label: "Leased" }
+      - label: "RPKI ROA"
+        width: 75
+        cellType: dropdown
+        fieldSuffix: rpki
+        options:
+          - { value: valid, label: "Valid" }
+          - { value: pending, label: "Pending" }
+          - { value: none, label: "None" }
+      - label: "Protection"
+        width: 85
+        cellType: dropdown
+        fieldSuffix: protection
+        options:
+          - { value: always_on, label: "Always-On" }
+          - { value: on_demand, label: "On-Demand" }
+      - label: "Environment"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: environment
+        options:
+          - { value: production, label: "Production" }
+          - { value: dr, label: "Disaster Recovery" }
+          - { value: staging, label: "Staging" }
+          - { value: development, label: "Development" }
+
+  - type: table
+    label: "Prefix Traffic Return Configuration"
+    fieldPrefix: prefix_return
+    rowCount: 8
+    columns:
+      - { label: "Prefix (CIDR)", width: 120, cellType: text, fieldSuffix: cidr }
+      - label: "Return Method"
+        width: 110
+        cellType: dropdown
+        fieldSuffix: method
+        options:
+          - { value: gre_tunnel, label: "GRE Tunnel" }
+          - { value: direct_routing, label: "Direct Routing" }
+          - { value: proxy_protocol, label: "Proxy Protocol" }
+      - { label: "GRE Endpoint IP", width: 120, cellType: text, fieldSuffix: gre_endpoint }
+      - label: "LOA Status"
+        width: 90
+        cellType: dropdown
+        fieldSuffix: loa
+        options:
+          - { value: submitted, label: "Submitted" }
+          - { value: pending, label: "Pending" }
+          - { value: not_required, label: "Not Required" }
+
+  - type: table
+    label: "Data Center Infrastructure"
+    fieldPrefix: dcinfra
+    rowCount: 8
+    columns:
+      - { label: "Data Center", width: 100, cellType: text, fieldSuffix: datacenter }
       - label: "Provider Type"
-        width: 150
+        width: 90
         cellType: dropdown
         fieldSuffix: provider
         options:
           - { value: onprem, label: "On-Prem" }
           - { value: colo, label: "Colo" }
           - { value: cloud, label: "Cloud" }
-      - { label: "Router Count", width: 100, cellType: text, fieldSuffix: routers }
-
-  - type: field
-    label: "Total Data Centers"
-    fieldType: text
-    fieldName: total_data_centers
-    width: 200
-
-  - type: heading
-    level: 3
-    text: "Edge Routers"
-
-  - type: paragraph
-    text: "EDGE/CORE/BORDER routers to monitor for DDoS attack detection?"
-
-  # Simplified table: using fieldPrefix + rowCount
-  - type: table
-    label: "Router Inventory"
-    fieldPrefix: router
-    rowCount: 4
-    columns:
-      - { label: "Location", width: 150, cellType: text, fieldSuffix: location }
+      - { label: "Router Name", width: 100, cellType: text, fieldSuffix: router_name }
       - label: "Router Type"
-        width: 120
+        width: 80
         cellType: dropdown
-        fieldSuffix: type
+        fieldSuffix: router_type
         options:
           - { value: edge, label: "Edge" }
           - { value: core, label: "Core" }
           - { value: border, label: "Border" }
-      - { label: "Vendor/Model", width: 150, cellType: text, fieldSuffix: model }
+      - label: "Vendor"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: vendor
+        options:
+          - { value: arista, label: "Arista" }
+          - { value: cisco_asr, label: "Cisco ASR" }
+          - { value: cisco_catalyst, label: "Cisco Catalyst" }
+          - { value: cisco_isr, label: "Cisco ISR" }
+          - { value: cisco_ncs, label: "Cisco NCS" }
+          - { value: cisco_nexus, label: "Cisco Nexus" }
+          - { value: dell_powerswitch, label: "Dell PowerSwitch" }
+          - { value: extreme_slx, label: "Extreme SLX" }
+          - { value: extreme_vsp, label: "Extreme VSP" }
+          - { value: fortinet_fortigate, label: "Fortinet FortiGate" }
+          - { value: h3c_cr, label: "H3C CR" }
+          - { value: hpe_aruba, label: "HPE Aruba" }
+          - { value: hpe_flexnetwork, label: "HPE FlexNetwork" }
+          - { value: huawei_ar, label: "Huawei AR" }
+          - { value: huawei_netengine, label: "Huawei NetEngine" }
+          - { value: juniper_acx, label: "Juniper ACX" }
+          - { value: juniper_mx, label: "Juniper MX" }
+          - { value: juniper_ptx, label: "Juniper PTX" }
+          - { value: juniper_srx, label: "Juniper SRX" }
+          - { value: mikrotik_ccr, label: "MikroTik CCR" }
+          - { value: mikrotik_routerboard, label: "MikroTik RouterBOARD" }
+          - { value: nokia_ixr, label: "Nokia IXR" }
+          - { value: nokia_sr, label: "Nokia SR" }
+          - { value: paloalto, label: "Palo Alto" }
+          - { value: ubiquiti_edgerouter, label: "Ubiquiti EdgeRouter" }
+          - { value: zte_zxr, label: "ZTE ZXR" }
+          - { value: other, label: "Other" }
 
-  - type: field
-    label: "Total Edge Routers"
-    fieldType: text
-    fieldName: total_edge_routers
-    width: 200
-
-  - type: heading
-    level: 3
-    text: "Bandwidth Requirements"
-
-  - type: paragraph
-    text: "Please provide the amount of CLEAN BANDWIDTH utilized by the network prefixes you would like to protect:"
-
-  # Simplified table: using values syntax for label+field rows
   - type: table
     label: "Bandwidth Metrics"
     columns:
@@ -254,40 +326,8 @@ content:
       - values: ["Peak Inbound Bandwidth", "bandwidth_peak"]
       - values: ["Average Inbound Bandwidth", "bandwidth_avg"]
 
-  # ===========================================
-  # PAGE 3: Protection Mode & Attack Types
-  # ===========================================
-  - type: heading
-    level: 2
-    text: "Protection Mode & Attack Types"
-
-  - type: heading
-    level: 3
-    text: "Mode of Protection"
-
-  - type: paragraph
-    text: "Please select your preferred protection mode:"
-
-  # Simplified table: using values syntax for label+checkbox rows
   - type: table
-    label: "Protection Mode Selection"
-    columns:
-      - { label: "Mode", width: 300, cellType: label }
-      - { label: "Select", width: 80, cellType: checkbox }
-    rows:
-      - values: ["CONTINUOUS (Always On)", "mode_continuous"]
-      - values: ["ON-DEMAND (Always Available)", "mode_ondemand"]
-
-  - type: heading
-    level: 3
-    text: "Activation Method (On-Demand Only)"
-
-  - type: paragraph
-    text: "If On-Demand, how should mitigation be activated?"
-
-  # Simplified table: using values syntax
-  - type: table
-    label: "Activation Method"
+    label: "Activation Method for On-Demand)"
     columns:
       - { label: "Method", width: 300, cellType: label }
       - { label: "Select", width: 80, cellType: checkbox }
@@ -296,91 +336,76 @@ content:
       - values: ["Manual (Customer initiates activation)", "activation_manual"]
       - values: ["Hybrid (Auto-detect with manual confirmation)", "activation_hybrid"]
 
-  # Simplified table: using values syntax
-  - type: table
-    columns:
-      - { label: "Acceptable time to mitigate (minutes)", width: 280, cellType: label }
-      - { label: "Value", width: 100, cellType: text }
-    rows:
-      - values: ["Mitigation Time", "mitigation_time"]
+  - type: field
+    label: "Acceptable time to mitigate (minutes):"
+    fieldType: text
+    fieldName: mitigation_time
+    labelPosition: left
+    labelWidth: 200
+    width: 100
 
   - type: heading
+    text: "L3/L4 Attack Types Protection"
     level: 3
-    text: "L3/L4 Volumetric Attacks"
 
   - type: paragraph
-    text: "Attack types to protect against:"
+    text: "Select the attack types you require protection against. Cloud DDoS providers typically offer protection against all listed attack vectors as part of their L3/L4 mitigation services."
 
-  # Two-column attack type selection (label + checkbox pairs)
   - type: table
-    label: "L3/L4 Attack Types"
+    label: "Volumetric Flood Attacks"
     columns:
       - { label: "Attack Type", width: 180, cellType: label }
       - { label: "Select", width: 60, cellType: checkbox }
       - { label: "Attack Type", width: 180, cellType: label }
       - { label: "Select", width: 60, cellType: checkbox }
     rows:
-      - values: ["UDP Floods", "attack_udp_floods", "SSDP Amplification", "attack_ssdp_amp"]
-      - values: ["TCP SYN Floods", "attack_tcp_syn", "Memcached Amplification", "attack_memcached"]
-      - values: ["TCP ACK Floods", "attack_tcp_ack", "Fragmentation Attacks", "attack_fragmentation"]
-      - values: ["ICMP Floods", "attack_icmp", "Teardrop Attacks", "attack_teardrop"]
-      - values: ["DNS Amplification", "attack_dns_amp", "Smurf Attacks", "attack_smurf"]
-      - values: ["NTP Amplification", "attack_ntp_amp", "", ""]
+      - values: ["UDP Flood", "attack_udp_flood", "ICMP Flood", "attack_icmp_flood"]
+      - values: ["IP Fragmentation Flood", "attack_ip_frag", "Smurf Attack", "attack_smurf"]
+      - values: ["IP Null Attack", "attack_ip_null", "Land Attack", "attack_land"]
 
-  - type: heading
-    level: 3
-    text: "L7 Application-Layer Attacks"
-
-  - type: paragraph
-    text: "Do you need L7 application-layer protection?"
-
-  # Simplified table: using values syntax
   - type: table
-    label: "L7 Protection Required"
-    columns:
-      - { label: "Option", width: 300, cellType: label }
-      - { label: "Select", width: 80, cellType: checkbox }
-    rows:
-      - values: ["Yes - Requires Advanced tier or WAF", "l7_required_yes"]
-      - values: ["No", "l7_required_no"]
-
-  - type: paragraph
-    text: "Attack types to protect against:"
-
-  # Two-column attack type selection
-  - type: table
-    label: "L7 Attack Types"
+    label: "TCP Protocol Attacks"
     columns:
       - { label: "Attack Type", width: 180, cellType: label }
       - { label: "Select", width: 60, cellType: checkbox }
       - { label: "Attack Type", width: 180, cellType: label }
       - { label: "Select", width: 60, cellType: checkbox }
     rows:
-      - values: ["HTTP Floods", "attack_http_floods", "SSL/TLS Exhaustion", "attack_ssl_exhaustion"]
-      - values: ["Slowloris", "attack_slowloris", "API Abuse", "attack_api_abuse"]
-      - values: ["Slow POST", "attack_slow_post", "Login Page Attacks", "attack_login_page"]
-      - values: ["DNS Query Floods", "attack_dns_query", "", ""]
+      - values: ["TCP SYN Flood", "attack_tcp_syn", "TCP ACK Flood", "attack_tcp_ack"]
+      - values: ["TCP RST Flood", "attack_tcp_rst", "TCP FIN Flood", "attack_tcp_fin"]
+      - values: ["TCP SYN/ACK Reflection", "attack_syn_ack_ref", "TCP Out-of-State", "attack_tcp_oos"]
+      - values: ["TCP Connection Exhaustion", "attack_tcp_conn", "Sockstress Attack", "attack_sockstress"]
 
-  - type: admonition
-    variant: warning
-    title: "L7 DDoS"
-    text: "Layer 7 DDoS mitigation with ML-based anomaly detection requires the Advanced WAAP tier."
+  - type: table
+    label: "Amplification/Reflection Attacks"
+    columns:
+      - { label: "Attack Type", width: 180, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
+      - { label: "Attack Type", width: 180, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
+    rows:
+      - values: ["DNS Amplification", "attack_dns_amp", "NTP Amplification", "attack_ntp_amp"]
+      - values: ["Memcached Amplification", "attack_memcached", "SSDP Amplification", "attack_ssdp"]
+      - values: ["CLDAP Amplification", "attack_cldap", "SNMP Amplification", "attack_snmp"]
+      - values: ["CharGEN Amplification", "attack_chargen", "TFTP Amplification", "attack_tftp"]
+      - values: ["RDP Reflection", "attack_rdp_ref", "mDNS Amplification", "attack_mdns"]
+      - values: ["NetBIOS Amplification", "attack_netbios", "LDAP Amplification", "attack_ldap"]
+      - values: ["WS-Discovery Amplification", "attack_wsdiscovery", "ARMS Amplification", "attack_arms"]
+      - values: ["CoAP Amplification", "attack_coap", "Portmap Amplification", "attack_portmap"]
 
-  # ===========================================
-  # PAGE 4: Detection, Alerting & Integration
-  # ===========================================
-  - type: heading
-    level: 2
-    text: "Detection, Alerting & Integration"
+  - type: table
+    label: "Advanced/Multi-Vector Attacks"
+    columns:
+      - { label: "Attack Type", width: 180, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
+      - { label: "Attack Type", width: 180, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
+    rows:
+      - values: ["Carpet Bombing", "attack_carpet_bomb", "Pulse Wave Attack", "attack_pulse"]
+      - values: ["Multi-Vector DDoS", "attack_multi_vector", "Teardrop Attack", "attack_teardrop"]
+      - values: ["GRE Flood", "attack_gre_flood", "ESP Flood", "attack_esp_flood"]
+      - values: ["Protocol 0 Attack", "attack_proto_0", "IP Option Abuse", "attack_ip_option"]
 
-  - type: heading
-    level: 3
-    text: "Detection Requirements"
-
-  - type: paragraph
-    text: "How should DDoS attacks be detected?"
-
-  # Simplified table: using values syntax
   - type: table
     label: "Detection Methods"
     columns:
@@ -391,69 +416,6 @@ content:
       - values: ["Inline detection (Always On mode)", "detect_inline"]
       - values: ["External monitoring integration", "detect_external"]
 
-  - type: heading
-    level: 3
-    text: "Alerting Requirements"
-
-  - type: paragraph
-    text: "How do you want to be notified of attacks?"
-
-  # Two-column alert method selection
-  - type: table
-    label: "Alert Methods"
-    columns:
-      - { label: "Alert Method", width: 180, cellType: label }
-      - { label: "Select", width: 60, cellType: checkbox }
-      - { label: "Alert Method", width: 180, cellType: label }
-      - { label: "Select", width: 60, cellType: checkbox }
-    rows:
-      - values: ["Email alerts", "alert_email", "Webhook/API integration", "alert_webhook"]
-      - values: ["SMS/Text alerts", "alert_sms", "SIEM integration", "alert_siem"]
-      - values: ["Phone call (24x7 SOC)", "alert_phone", "", ""]
-
-  - type: paragraph
-    text: "Alert contacts:"
-
-  # Contact table with label column + text fields
-  - type: table
-    label: "Alert Contacts"
-    columns:
-      - { label: "Contact Type", width: 100, cellType: label }
-      - { label: "Name", width: 120, cellType: text }
-      - { label: "Email", width: 150, cellType: text }
-      - { label: "Phone", width: 110, cellType: text }
-    rows:
-      - values: ["Primary", "contact_primary_name", "contact_primary_email", "contact_primary_phone"]
-      - values: ["Secondary", "contact_secondary_name", "contact_secondary_email", "contact_secondary_phone"]
-      - values: ["Escalation", "contact_escalation_name", "contact_escalation_email", "contact_escalation_phone"]
-
-  - type: heading
-    level: 3
-    text: "Reporting Requirements"
-
-  - type: paragraph
-    text: "What DDoS reporting do you need?"
-
-  # Two-column report type selection
-  - type: table
-    label: "Reporting Options"
-    columns:
-      - { label: "Report Type", width: 180, cellType: label }
-      - { label: "Select", width: 60, cellType: checkbox }
-      - { label: "Report Type", width: 180, cellType: label }
-      - { label: "Select", width: 60, cellType: checkbox }
-    rows:
-      - values: ["Real-time attack dashboard", "report_realtime", "Monthly summary reports", "report_monthly"]
-      - values: ["Post-attack reports", "report_post_attack", "Custom reporting", "report_custom"]
-
-  - type: heading
-    level: 3
-    text: "BGP Integration"
-
-  - type: paragraph
-    text: "Will you establish BGP sessions with F5 for traffic diversion?"
-
-  # Simplified table: using values syntax
   - type: table
     label: "BGP Options"
     columns:
@@ -464,23 +426,14 @@ content:
       - values: ["Yes - Through IX (Internet Exchange)", "bgp_ix"]
       - values: ["No - DNS-based diversion only", "bgp_dns_only"]
 
-  - type: paragraph
-    text: "BGP session details (if applicable):"
-
-  # Simplified table: using fieldPrefix + rowCount
   - type: table
     label: "BGP Session Details"
     fieldPrefix: bgp
-    rowCount: 2
+    rowCount: 8
     columns:
       - { label: "Peer Location", width: 200, cellType: text, fieldSuffix: peer_location }
       - { label: "Your Router IP", width: 200, cellType: text, fieldSuffix: router_ip }
 
-  - type: heading
-    level: 3
-    text: "GRE Tunnel Requirements"
-
-  # Simplified table: using values syntax
   - type: table
     label: "GRE Tunnel Options"
     columns:
@@ -490,51 +443,74 @@ content:
       - values: ["Yes - GRE tunnels to our routers", "gre_yes"]
       - values: ["No - Direct routing", "gre_no"]
 
-  # Simplified table: using values syntax
   - type: table
+    label: "Existing Cloud DDoS Providers"
+    fieldPrefix: existing
+    rowCount: 4
     columns:
-      - { label: "Number of GRE tunnel endpoints", width: 250, cellType: label }
-      - { label: "Count", width: 100, cellType: text }
-    rows:
-      - values: ["GRE Endpoints", "gre_endpoints"]
-
-  # ===========================================
-  # PAGE 5: Service Level & Summary
-  # ===========================================
-  - type: heading
-    level: 2
-    text: "Service Level & Summary"
-
-  - type: heading
-    level: 3
-    text: "Existing DDoS Solutions"
-
-  - type: paragraph
-    text: "Do you have existing DDoS protection?"
-
-  # Existing solutions table with dropdown
-  - type: table
-    label: "Existing Solutions"
-    columns:
-      - { label: "Solution", width: 150, cellType: text }
-      - { label: "Provider", width: 150, cellType: text }
-      - label: "Action"
-        width: 150
+      - label: "Provider"
+        width: 225
         cellType: dropdown
+        fieldSuffix: provider
+        options:
+          - { value: akamai, label: "Akamai Prolexic" }
+          - { value: aws, label: "AWS Shield Advanced" }
+          - { value: azure, label: "Azure DDoS Protection" }
+          - { value: cloudflare, label: "Cloudflare Magic Transit" }
+          - { value: f5, label: "F5 Distributed Cloud DDoS" }
+          - { value: fastly, label: "Fastly DDoS Protection" }
+          - { value: gcore, label: "Gcore DDoS Protection" }
+          - { value: google, label: "Google Cloud Armor" }
+          - { value: imperva, label: "Imperva DDoS Protection" }
+          - { value: link11, label: "Link11 DDoS Protection" }
+          - { value: lumen, label: "Lumen DDoS Mitigation" }
+          - { value: netscout, label: "NETSCOUT Arbor Cloud" }
+          - { value: nexusguard, label: "Nexusguard DDoS Protection" }
+          - { value: ovhcloud, label: "OVHcloud Anti-DDoS" }
+          - { value: radware, label: "Radware Cloud DDoS Protection" }
+          - { value: sucuri, label: "Sucuri Website Firewall" }
+          - { value: vercara, label: "Vercara UltraDDoS Protect" }
+          - { value: other, label: "Other" }
+          - { value: none, label: "None" }
+      - label: "Action"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: action
         options:
           - { value: replace, label: "Replace" }
           - { value: layer, label: "Layer" }
-    rows:
-      - values: ["existing_solution", "existing_provider", "existing_action"]
+          - { value: keep, label: "Keep" }
 
-  - type: heading
-    level: 3
-    text: "SLA Requirements"
+  - type: table
+    label: "Existing Hardware DDoS Providers"
+    fieldPrefix: hardware_ddos
+    rowCount: 4
+    columns:
+      - label: "Provider"
+        width: 225
+        cellType: dropdown
+        fieldSuffix: provider
+        options:
+          - { value: a10, label: "A10 Networks Thunder TPS" }
+          - { value: checkpoint, label: "Check Point Quantum DDoS Protector" }
+          - { value: corero, label: "Corero SmartWall ONE" }
+          - { value: f5, label: "F5 DDoS Hybrid Defender" }
+          - { value: fortinet, label: "Fortinet FortiDDoS" }
+          - { value: huawei, label: "Huawei AntiDDoS" }
+          - { value: netscout, label: "NETSCOUT Arbor Edge Defense (AED)" }
+          - { value: nsfocus, label: "NSFOCUS ADS" }
+          - { value: radware, label: "Radware DefensePro" }
+          - { value: other, label: "Other" }
+          - { value: none, label: "None" }
+      - label: "Action"
+        width: 100
+        cellType: dropdown
+        fieldSuffix: action
+        options:
+          - { value: replace, label: "Replace" }
+          - { value: layer, label: "Layer" }
+          - { value: keep, label: "Keep" }
 
-  - type: paragraph
-    text: "What SLA requirements do you have?"
-
-  # Simplified table: using values syntax
   - type: table
     label: "SLA Metrics"
     columns:
@@ -546,106 +522,59 @@ content:
       - values: ["Uptime SLA (%)", "sla_uptime"]
       - values: ["False Positive Rate (%)", "sla_false_positive"]
 
-  - type: heading
-    level: 3
-    text: "Support Level"
-
-  - type: paragraph
-    text: "What level of DDoS support do you need?"
-
-  # Simplified table: using values syntax
   - type: table
-    label: "Support Options"
+    label: "Reporting Options"
     columns:
-      - { label: "Support Level", width: 300, cellType: label }
-      - { label: "Select", width: 80, cellType: checkbox }
+      - { label: "Report Type", width: 174, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
     rows:
-      - values: ["Standard - Business hours support", "support_standard"]
-      - values: ["Enhanced - 24x7 SOC monitoring", "support_enhanced"]
-      - values: ["Enhanced Plus - Dedicated SOC resources", "support_enhanced_plus"]
+      - values: ["Real-time attack dashboard", "report_realtime"]
+      - values: ["Monthly summary reports", "report_monthly"]
+      - values: ["Post-attack reports", "report_post_attack"]
+      - values: ["Custom reporting", "report_custom"]
 
-  - type: rule
-
-  - type: heading
-    level: 2
-    text: "Summary: DDoS Protection Requirements"
-
-  # Summary table with mixed label+text and label+dropdown
-  - type: table
-    label: "Requirements Summary"
-    columns:
-      - { label: "Requirement", width: 250, cellType: label }
-      - { label: "Value", width: 200 }
-    rows:
-      - cells:
-          - { type: label, value: "Customer ASN" }
-          - type: dropdown
-            fieldName: summary_has_asn
-            options:
-              - { value: yes, label: "Yes" }
-              - { value: no, label: "No" }
-      - cells:
-          - { type: label, value: "Number of Prefixes" }
-          - { type: text, fieldName: summary_prefixes }
-      - cells:
-          - { type: label, value: "Number of Data Centers" }
-          - { type: text, fieldName: summary_data_centers }
-      - cells:
-          - { type: label, value: "Number of Edge Routers" }
-          - { type: text, fieldName: summary_edge_routers }
-      - cells:
-          - { type: label, value: "Clean Bandwidth (95th percentile) Mbps" }
-          - { type: text, fieldName: summary_bandwidth }
-      - cells:
-          - { type: label, value: "Protection Mode" }
-          - type: dropdown
-            fieldName: summary_protection_mode
-            options:
-              - { value: always_on, label: "Always On" }
-              - { value: on_demand, label: "On-Demand" }
-      - cells:
-          - { type: label, value: "L3/L4 Protection" }
-          - type: dropdown
-            fieldName: summary_l3l4
-            options:
-              - { value: yes, label: "Yes" }
-              - { value: no, label: "No" }
-      - cells:
-          - { type: label, value: "L7 Protection" }
-          - type: dropdown
-            fieldName: summary_l7
-            options:
-              - { value: yes, label: "Yes" }
-              - { value: no, label: "No" }
-      - cells:
-          - { type: label, value: "Support Level" }
-          - type: dropdown
-            fieldName: summary_support
-            options:
-              - { value: standard, label: "Standard" }
-              - { value: enhanced, label: "Enhanced" }
-              - { value: enhanced_plus, label: "Enhanced Plus" }
-
-  - type: paragraph
-    text: "Network diagram attached:"
+  - type: field
+    label: "Support Level:"
+    fieldType: dropdown
+    fieldName: support_level
+    labelPosition: left
+    labelWidth: 100
+    width: 250
+    options:
+      - { value: standard, label: "Standard - Business hours" }
+      - { value: enhanced, label: "Enhanced - 24x7 SOC" }
+      - { value: enhanced_plus, label: "Enhanced Plus - Dedicated SOC" }
 
   - type: table
+    label: "Alerts"
     columns:
-      - { label: "Diagram Attached", width: 150, cellType: label }
-      - { label: "Yes", width: 60, cellType: checkbox }
-      - { label: "No", width: 60, cellType: checkbox }
+      - { label: "Method", width: 180, cellType: label }
+      - { label: "Select", width: 60, cellType: checkbox }
     rows:
-      - values: ["", "diagram_attached_yes", "diagram_attached_no"]
-
-  - type: paragraph
-    text: "Additional notes or special requirements:"
+      - values: ["Email alerts", "alert_email"]
+      - values: ["Webhook/API integration", "alert_webhook"]
+      - values: ["SMS/Text alerts", "alert_sms"]
+      - values: ["SIEM integration", "alert_siem"]
+      - values: ["Phone call (24x7 SOC)", "alert_phone", "", ""]
 
   - type: table
-    label: "Additional Notes"
+    label: "Alert Contacts"
     columns:
-      - { label: "Notes", width: 468, cellType: text }
+      - { label: "Contact", width: 88, cellType: label }
+      - { label: "Name", width: 120, cellType: text }
+      - { label: "Email", width: 150, cellType: text }
+      - { label: "Phone", width: 110, cellType: text }
     rows:
-      - values: ["additional_notes"]
+      - values: ["Primary", "contact_primary_name", "contact_primary_email", "contact_primary_phone"]
+      - values: ["Secondary", "contact_secondary_name", "contact_secondary_email", "contact_secondary_phone"]
+      - values: ["Escalation", "contact_escalation_name", "contact_escalation_email", "contact_escalation_phone"]
 
-# Empty fields array - all fields are now embedded in tables
+  - type: field
+    label: "Additional Notes:"
+    labelPosition: above
+    fieldType: textarea
+    fieldName: additional_notes
+    width: 468
+    height: 120
+
 fields: []

--- a/schemas/form-schema.json
+++ b/schemas/form-schema.json
@@ -50,6 +50,11 @@
         "stylesheet": {
           "type": "string",
           "description": "Path to custom CSS stylesheet for PDF styling"
+        },
+        "numbering": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable auto-numbering for standalone field labels (1., 2., 3., etc.)"
         }
       }
     },
@@ -310,6 +315,11 @@
                 "type": "number",
                 "minimum": 20,
                 "description": "Field width in points (default: content width)"
+              },
+              "height": {
+                "type": "number",
+                "minimum": 20,
+                "description": "Field height in points (for textarea, default: 60)"
               },
               "options": {
                 "type": "array",

--- a/src/generators/pdf/content.ts
+++ b/src/generators/pdf/content.ts
@@ -146,7 +146,8 @@ function estimateElementHeight(ctx: LayoutContext, element: SchemaContentElement
     case 'field': {
       const fieldEl = element as FieldContent;
       const labelHeight = ctx.stylesheet.fields.label.fontSize + 4;
-      const fieldHeight = fieldEl.fieldType === 'textarea' ? 60 : 22;
+      const defaultHeight = fieldEl.fieldType === 'textarea' ? 60 : 22;
+      const fieldHeight = fieldEl.height ?? defaultHeight;
       return labelHeight + fieldHeight + FLOW_SPACING.field.marginTop + FLOW_SPACING.field.marginBottom;
     }
 
@@ -483,7 +484,10 @@ async function drawFieldContent(
   let fieldY: number;
   let fieldWidth: number;
   let fieldHeight: number;
-  if (element.fieldType === 'textarea') {
+  if (element.height) {
+    // Use custom height if specified
+    fieldHeight = element.height;
+  } else if (element.fieldType === 'textarea') {
     fieldHeight = 60;
   } else {
     // Match table cell field height for visual consistency

--- a/src/parsers/schema.ts
+++ b/src/parsers/schema.ts
@@ -105,6 +105,25 @@ export async function parseSchema(filePath: string): Promise<ParsedFormSchema> {
     );
   }
 
+  // Apply auto-numbering to fields and tables if enabled
+  if (schema.form?.numbering && schema.content) {
+    let counter = 0;
+    for (const element of schema.content) {
+      if (element.type === 'field') {
+        counter++;
+        const fieldElement = element as import('../types/index.js').FieldContent;
+        fieldElement.label = `${counter}. ${fieldElement.label}`;
+      } else if (element.type === 'table') {
+        counter++;
+        const tableElement = element as import('../types/index.js').TableContent;
+        // Prepend number to existing label, or create label with just the number
+        tableElement.label = tableElement.label
+          ? `${counter}. ${tableElement.label}`
+          : `${counter}.`;
+      }
+    }
+  }
+
   // Normalize fields
   const normalizedFields = schema.fields.map(normalizeField);
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -97,6 +97,7 @@ export interface FieldContent extends BaseContentElement {
   fieldType: 'text' | 'dropdown' | 'checkbox' | 'textarea';
   fieldName: string;       // Unique field identifier
   width?: number;          // Field width in points (default: full width)
+  height?: number;         // Field height in points (for textarea, default: 60)
   options?: FieldOption[]; // For dropdown fields
   default?: string | boolean;
   placeholder?: string;
@@ -208,6 +209,12 @@ export interface FormMetadata {
    * If not specified, uses default stylesheet.
    */
   stylesheet?: string;
+  /**
+   * Enable auto-numbering for standalone field labels.
+   * When true, field labels are prefixed with sequential numbers (1., 2., 3., etc.)
+   * Tables are excluded from numbering.
+   */
+  numbering?: boolean;
 }
 
 export interface FormSchema {


### PR DESCRIPTION
## Summary

Add support for auto-numbered fields and custom field heights to improve form flexibility and organization.

## Changes
- Add `numbering` metadata flag to enable sequential field numbering (1., 2., 3., etc.)
- Add `height` field property for custom field dimensions (especially textareas)
- Implement auto-numbering logic in schema parser for fields and tables
- Update PDF renderer to respect custom field heights
- Update DDoS schema with numbering enabled

## Benefits
- Better form organization with automatic sequential numbering
- Flexible field sizing for different input types
- Improved visual consistency in PDF forms

Closes #2