### PR TITLE
feat: add DNS services and load balancer assessment schemas

### DIFF
--- a/schemas/dns-services.yaml
+++ b/schemas/dns-services.yaml
@@ -1,0 +1,628 @@
+---
+form:
+  id: dns-services
+  title: DNS Services
+  version: '1.0.0'
+  author: Robin Mordasiewicz
+  description: Complete DNS Services requirements assessment form
+  positioning: flow
+  numbering: true
+
+content:
+  - type: heading
+    level: 1
+    text: 'DNS Services Questionnaire'
+
+  - type: paragraph
+    text: >
+      F5 Distributed Cloud DNS provides geo-distributed DNS services with global
+      server load balancing (GSLB), automatic failover, health checking, and DDoS
+      protection.
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 1: Organization Profile
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Organization Profile'
+
+  - type: field
+    label: 'Company Name:'
+    fieldType: text
+    fieldName: company_name
+    labelPosition: left
+    labelWidth: 150
+    width: 318
+
+  - type: field
+    label: 'Industry:'
+    fieldType: dropdown
+    fieldName: industry
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: financial, label: 'Financial Services'}
+      - {value: healthcare, label: 'Healthcare'}
+      - {value: government, label: 'Government'}
+      - {value: ecommerce, label: 'E-commerce/Retail'}
+      - {value: technology, label: 'Technology/SaaS'}
+      - {value: gaming, label: 'Gaming'}
+      - {value: media, label: 'Media/Entertainment'}
+      - {value: education, label: 'Education'}
+      - {value: manufacturing, label: 'Manufacturing'}
+      - {value: other, label: 'Other'}
+
+  - type: field
+    label: 'Compliance Requirements:'
+    fieldType: dropdown
+    fieldName: compliance
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: none, label: 'None specific'}
+      - {value: pci_dss, label: 'PCI-DSS'}
+      - {value: hipaa, label: 'HIPAA'}
+      - {value: fedramp, label: 'FedRAMP'}
+      - {value: soc2, label: 'SOC 2'}
+      - {value: gdpr, label: 'GDPR'}
+      - {value: multiple, label: 'Multiple'}
+
+  - type: field
+    label: 'Implementation Timeline:'
+    fieldType: dropdown
+    fieldName: timeline
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: urgent, label: 'Urgent'}
+      - {value: week, label: 'Within 1 week'}
+      - {value: month, label: 'Within 1 month'}
+      - {value: planning, label: 'Planning phase (3+ months)'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 2: DNS Service Requirements
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'DNS Service Requirements'
+
+  - type: field
+    label: 'DNS Service Type:'
+    fieldType: dropdown
+    fieldName: dns_service_type
+    labelPosition: left
+    labelWidth: 150
+    width: 250
+    options:
+      - {value: primary, label: 'Primary DNS hosting'}
+      - {value: secondary, label: 'Secondary DNS (backup)'}
+      - {value: gslb_only, label: 'DNS Load Balancing (GSLB) only'}
+      - {value: primary_gslb, label: 'Primary + GSLB'}
+
+  - type: table
+    label: 'Current DNS Providers'
+    fieldPrefix: current_dns
+    rowCount: 3
+    columns:
+      - {label: 'Provider Name', width: 200, cellType: text, fieldSuffix: name}
+      - label: 'Action'
+        width: 150
+        cellType: dropdown
+        fieldSuffix: action
+        options:
+          - {value: migrate, label: 'Migrate to F5'}
+          - {value: keep_primary, label: 'Keep as primary'}
+          - {value: keep_secondary, label: 'Keep as secondary'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 3: Zone Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Zone Configuration'
+
+  - type: table
+    label: 'Zone Count'
+    columns:
+      - {label: 'Zone Type', width: 240, cellType: label}
+      - {label: 'Count', width: 100, cellType: text}
+    rows:
+      - values: ['Primary Zones', 'zone_primary_count']
+      - values: ['Secondary Zones', 'zone_secondary_count']
+      - values: ['Total Zones', 'zone_total_count']
+
+  - type: table
+    label: 'Zone Details'
+    fieldPrefix: zone
+    rowCount: 5
+    columns:
+      - {label: 'Domain', width: 150, cellType: text, fieldSuffix: domain}
+      - label: 'Zone Type'
+        width: 100
+        cellType: dropdown
+        fieldSuffix: type
+        options:
+          - {value: primary, label: 'Primary'}
+          - {value: secondary, label: 'Secondary'}
+      - {label: 'Records (est.)', width: 90, cellType: text, fieldSuffix: records}
+      - {label: 'Query Volume (qps)', width: 128, cellType: text, fieldSuffix: qps}
+
+  - type: table
+    label: 'Record Types Used'
+    columns:
+      - {label: 'Record Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['A (IPv4 address)', 'record_type_a']
+      - values: ['AAAA (IPv6 address)', 'record_type_aaaa']
+      - values: ['ALIAS (Alias domain names)', 'record_type_alias']
+      - values: ['CNAME (Canonical name)', 'record_type_cname']
+      - values: ['MX (Mail exchange)', 'record_type_mx']
+      - values: ['TXT (Text records)', 'record_type_txt']
+      - values: ['SRV (Service records)', 'record_type_srv']
+      - values: ['NS (Nameserver)', 'record_type_ns']
+      - values: ['CAA (Certificate Authority Authorization)', 'record_type_caa']
+      - values: ['PTR (Reverse DNS)', 'record_type_ptr']
+      - values: ['NAPTR (Naming Authority Pointer)', 'record_type_naptr']
+      - values: ['DS (Delegation Signer for DNSSEC)', 'record_type_ds']
+      - values: ['LOC (Geographic location)', 'record_type_loc']
+      - values: ['SSHFP (SSH key fingerprint)', 'record_type_sshfp']
+      - values: ['TLSA (TLS certificate association)', 'record_type_tlsa']
+
+  - type: field
+    label: 'Total Estimated DNS Records:'
+    fieldType: text
+    fieldName: total_dns_records
+    labelPosition: left
+    labelWidth: 200
+    width: 100
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 4: DNS Load Balancing (GSLB)
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'DNS Load Balancing (GSLB)'
+
+  - type: field
+    label: 'GSLB Required:'
+    fieldType: dropdown
+    fieldName: gslb_required
+    labelPosition: left
+    labelWidth: 150
+    width: 280
+    options:
+      - {value: yes, label: 'Yes - Distribute traffic across locations'}
+      - {value: no, label: 'No - Basic DNS only'}
+
+  - type: table
+    label: 'Load Balancing Methods'
+    columns:
+      - {label: 'Method', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Round-robin - Equal distribution among pool members', 'gslb_round_robin']
+      - values: ['Ratio/Weighted - Distribute traffic by configured ratios', 'gslb_ratio']
+      - values: ['Priority - Route based on priority values (failover)', 'gslb_priority']
+      - values: ['Geo-location - Route users to nearest data center', 'gslb_geo_location']
+      - values: ['ASN-based - Route based on client ASN/ISP', 'gslb_asn']
+      - values: ['IP Prefix - Route based on client IP prefix', 'gslb_ip_prefix']
+
+  - type: table
+    label: 'DNS LB Records'
+    fieldPrefix: dns_lb
+    rowCount: 5
+    columns:
+      - {label: 'Record/Domain', width: 150, cellType: text, fieldSuffix: domain}
+      - label: 'Type'
+        width: 120
+        cellType: dropdown
+        fieldSuffix: type
+        options:
+          - {value: round_robin, label: 'Round-robin'}
+          - {value: ratio, label: 'Ratio/Weighted'}
+          - {value: priority, label: 'Priority'}
+          - {value: geo, label: 'Geo-location'}
+      - {label: 'Locations', width: 198, cellType: text, fieldSuffix: locations}
+
+  - type: field
+    label: 'Total DNS LB Records:'
+    fieldType: text
+    fieldName: total_dns_lb_records
+    labelPosition: left
+    labelWidth: 150
+    width: 100
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 5: Health Checking
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Health Checking'
+
+  - type: field
+    label: 'Health Checks Required:'
+    fieldType: dropdown
+    fieldName: health_checks_required
+    labelPosition: left
+    labelWidth: 160
+    width: 100
+    options:
+      - {value: yes, label: 'Yes'}
+      - {value: no, label: 'No'}
+
+  - type: table
+    label: 'Health Check Details'
+    fieldPrefix: health_check
+    rowCount: 5
+    columns:
+      - {label: 'Target', width: 180, cellType: text, fieldSuffix: target}
+      - label: 'Check Type'
+        width: 120
+        cellType: dropdown
+        fieldSuffix: type
+        options:
+          - {value: http, label: 'HTTP'}
+          - {value: https, label: 'HTTPS'}
+          - {value: tcp, label: 'TCP'}
+          - {value: udp, label: 'UDP'}
+          - {value: icmp, label: 'ICMP'}
+      - {label: 'Send/Receive String', width: 168, cellType: text, fieldSuffix: payload}
+
+  - type: field
+    label: 'Total Health Checks:'
+    fieldType: text
+    fieldName: total_health_checks
+    labelPosition: left
+    labelWidth: 150
+    width: 100
+
+  - type: paragraph
+    text: >
+      Note: Health check interval is fixed at 30 seconds with 90-second timeout (3x interval).
+      Members automatically recover when responding correctly.
+
+  - type: table
+    label: 'Failover Configuration'
+    columns:
+      - {label: 'Parameter', width: 240, cellType: label}
+      - {label: 'Value', width: 150, cellType: text}
+    rows:
+      - values: ['TTL during failover (seconds)', 'failover_ttl']
+      - values: ['Maximum answers per response', 'max_answers']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 6: DNS Security
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'DNS Security'
+
+  - type: field
+    label: 'DNSSEC Required:'
+    fieldType: dropdown
+    fieldName: dnssec_required
+    labelPosition: left
+    labelWidth: 150
+    width: 220
+    options:
+      - {value: yes, label: 'Yes - Sign DNS responses'}
+      - {value: no, label: 'No'}
+      - {value: evaluating, label: 'Evaluating'}
+
+  - type: paragraph
+    text: >
+      Note: DNSSEC is provider-managed with automatic key rotation. DS records are
+      auto-generated and must be added to your parent zone.
+
+  - type: field
+    label: 'DNS DDoS Protection:'
+    fieldType: dropdown
+    fieldName: dns_ddos_protection
+    labelPosition: left
+    labelWidth: 150
+    width: 180
+    options:
+      - {value: standard, label: 'Standard (included)'}
+      - {value: advanced, label: 'Advanced'}
+      - {value: not_required, label: 'Not required'}
+
+  - type: table
+    label: 'DNS Attack History'
+    columns:
+      - {label: 'Attack Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['DNS floods', 'attack_dns_floods']
+      - values: ['DNS amplification', 'attack_dns_amplification']
+      - values: ['NXDOMAIN attacks', 'attack_nxdomain']
+      - values: ['None', 'attack_none']
+
+  - type: table
+    label: 'Access Control'
+    columns:
+      - {label: 'Control Method', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['TSIG authentication for zone transfers', 'access_tsig']
+      - values: ['IP-based access restrictions', 'access_ip_restrictions']
+      - values: ['Rate limiting per client', 'access_rate_limiting']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 7: Zone Management
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Zone Management'
+
+  - type: field
+    label: 'Zone Transfer Required:'
+    fieldType: dropdown
+    fieldName: zone_transfer_required
+    labelPosition: left
+    labelWidth: 160
+    width: 260
+    options:
+      - {value: f5_primary, label: 'Yes - F5 as primary'}
+      - {value: external_primary, label: 'Yes - External primary (F5 secondary)'}
+      - {value: no, label: 'No'}
+
+  - type: table
+    label: 'External DNS Servers'
+    fieldPrefix: external_dns
+    rowCount: 3
+    columns:
+      - {label: 'Server Name', width: 140, cellType: text, fieldSuffix: name}
+      - {label: 'IP Address', width: 140, cellType: text, fieldSuffix: ip}
+      - label: 'Direction'
+        width: 110
+        cellType: dropdown
+        fieldSuffix: direction
+        options:
+          - {value: to_f5, label: 'To F5'}
+          - {value: from_f5, label: 'From F5'}
+
+  - type: field
+    label: 'Zone Import:'
+    fieldType: dropdown
+    fieldName: zone_import
+    labelPosition: left
+    labelWidth: 100
+    width: 220
+    options:
+      - {value: standard, label: 'Yes - Standard zone file'}
+      - {value: bind, label: 'Yes - BIND format'}
+      - {value: no, label: 'No - Creating from scratch'}
+
+  - type: field
+    label: 'Zone Files to Import:'
+    fieldType: text
+    fieldName: zone_files_count
+    labelPosition: left
+    labelWidth: 150
+    width: 80
+
+  - type: table
+    label: 'DNS Management Method'
+    columns:
+      - {label: 'Method', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['F5 XC Console (UI)', 'mgmt_console']
+      - values: ['Terraform / Infrastructure as Code', 'mgmt_terraform']
+      - values: ['API integration', 'mgmt_api']
+      - values: ['CI/CD pipeline', 'mgmt_cicd']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 8: Query Volume
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Query Volume'
+
+  - type: table
+    label: 'Query Metrics'
+    columns:
+      - {label: 'Metric', width: 240, cellType: label}
+      - {label: 'Value', width: 150, cellType: text}
+    rows:
+      - values: ['Average queries per second', 'query_avg_qps']
+      - values: ['Peak queries per second', 'query_peak_qps']
+      - values: ['Daily query volume', 'query_daily_volume']
+      - values: ['Monthly query volume', 'query_monthly_volume']
+
+  - type: table
+    label: 'Query Sources by Region'
+    columns:
+      - {label: 'Region', width: 240, cellType: label}
+      - {label: 'Percentage (%)', width: 100, cellType: text}
+    rows:
+      - values: ['North America', 'region_na_pct']
+      - values: ['Europe', 'region_eu_pct']
+      - values: ['Asia-Pacific', 'region_apac_pct']
+      - values: ['South America', 'region_sa_pct']
+      - values: ['Other', 'region_other_pct']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 9: Advanced DNS LB Features
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Advanced DNS LB Features'
+
+  - type: table
+    label: 'Geo-Location Matching Criteria'
+    columns:
+      - {label: 'Matching Option', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['By country', 'geo_match_country']
+      - values: ['By region/continent', 'geo_match_region']
+      - values: ['By ASN (Autonomous System Number)', 'geo_match_asn']
+      - values: ['By BGP ASN Sets', 'geo_match_bgp_asn']
+      - values: ['By IP Prefix (IPv4/IPv6)', 'geo_match_ip_prefix']
+      - values: ['By IP Prefix Sets', 'geo_match_ip_prefix_sets']
+
+  - type: field
+    label: 'Response Caching:'
+    fieldType: dropdown
+    fieldName: response_caching
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: enabled, label: 'Enabled'}
+      - {value: disabled, label: 'Disabled'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 10: Existing DNS Providers
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Existing DNS Providers'
+
+  - type: table
+    label: 'Cloud DNS Providers'
+    fieldPrefix: cloud_dns
+    rowCount: 4
+    columns:
+      - label: 'Provider'
+        width: 240
+        cellType: dropdown
+        fieldSuffix: provider
+        options:
+          - {value: aws_route53, label: 'AWS Route 53'}
+          - {value: azure_dns, label: 'Azure DNS'}
+          - {value: google_cloud_dns, label: 'Google Cloud DNS'}
+          - {value: cloudflare, label: 'Cloudflare DNS'}
+          - {value: akamai, label: 'Akamai Edge DNS'}
+          - {value: ns1, label: 'NS1'}
+          - {value: dnsmadeeasy, label: 'DNSMadeEasy'}
+          - {value: dyn, label: 'Dyn (Oracle)'}
+          - {value: ultradns, label: 'UltraDNS (Vercara)'}
+          - {value: godaddy, label: 'GoDaddy DNS'}
+          - {value: namecheap, label: 'Namecheap DNS'}
+          - {value: digitalocean, label: 'DigitalOcean DNS'}
+          - {value: linode, label: 'Linode DNS'}
+          - {value: bind, label: 'BIND (self-hosted)'}
+          - {value: windows_dns, label: 'Windows DNS Server'}
+          - {value: infoblox, label: 'Infoblox'}
+          - {value: f5, label: 'F5 Distributed Cloud DNS'}
+          - {value: other, label: 'Other'}
+          - {value: none, label: 'None'}
+      - label: 'Action'
+        width: 100
+        cellType: dropdown
+        fieldSuffix: action
+        options:
+          - {value: replace, label: 'Replace'}
+          - {value: layer, label: 'Layer'}
+          - {value: keep, label: 'Keep'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 11: Operations & Support
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Operations & Support'
+
+  - type: table
+    label: 'SLA Metrics'
+    columns:
+      - {label: 'SLA Metric', width: 240, cellType: label}
+      - {label: 'Value', width: 100, cellType: text}
+    rows:
+      - values: ['Query response time (ms)', 'sla_response_time']
+      - values: ['Uptime SLA (%)', 'sla_uptime']
+      - values: ['Propagation time (sec)', 'sla_propagation_time']
+
+  - type: table
+    label: 'Reporting Options'
+    columns:
+      - {label: 'Report Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Real-time dashboard', 'report_realtime']
+      - values: ['Monthly reports', 'report_monthly']
+      - values: ['Query analytics', 'report_analytics']
+      - values: ['Custom reporting', 'report_custom']
+
+  - type: field
+    label: 'Support Level:'
+    fieldType: dropdown
+    fieldName: support_level
+    labelPosition: left
+    labelWidth: 100
+    width: 240
+    options:
+      - {value: standard, label: 'Standard - Business hours'}
+      - {value: enhanced, label: 'Enhanced - 24x7 SOC'}
+      - {value: enhanced_plus, label: 'Enhanced Plus - Dedicated SOC'}
+
+  - type: table
+    label: 'Alert Methods'
+    columns:
+      - {label: 'Method', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Email', 'alert_email']
+      - values: ['Webhook/API', 'alert_webhook']
+      - values: ['SMS', 'alert_sms']
+      - values: ['SIEM integration', 'alert_siem']
+      - values: ['Phone (24x7 SOC)', 'alert_phone']
+
+  - type: table
+    label: '24/7 Emergency Contacts'
+    columns:
+      - {label: 'Contact', width: 88, cellType: label}
+      - {label: 'Name', width: 120, cellType: text}
+      - {label: 'Email', width: 150, cellType: text}
+      - {label: 'Phone', width: 110, cellType: text}
+    rows:
+      - values: ['Primary', 'contact_primary_name', 'contact_primary_email', 'contact_primary_phone']
+      - values: ['Secondary', 'contact_secondary_name', 'contact_secondary_email', 'contact_secondary_phone']
+      - values: ['Escalation', 'contact_escalation_name', 'contact_escalation_email', 'contact_escalation_phone']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 12: Additional Notes
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Additional Notes'
+
+  - type: field
+    label: 'Additional Notes:'
+    labelPosition: above
+    fieldType: textarea
+    fieldName: additional_notes
+    width: 468
+    height: 120
+
+fields: []

--- a/schemas/load-balancers.yaml
+++ b/schemas/load-balancers.yaml
@@ -1,0 +1,838 @@
+---
+form:
+  id: load-balancers
+  title: Load Balancers
+  version: '1.0.0'
+  author: Robin Mordasiewicz
+  description: Complete Load Balancer requirements assessment form for HTTP, TCP, and UDP
+  positioning: flow
+  numbering: true
+
+content:
+  - type: heading
+    level: 1
+    text: 'Load Balancer Sizing Questionnaire'
+
+  - type: paragraph
+    text: >
+      F5 Distributed Cloud provides HTTP, TCP, and UDP load balancing with global
+      distribution, automatic TLS management, and advanced traffic routing capabilities.
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 1: Organization Profile
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Organization Profile'
+
+  - type: field
+    label: 'Company Name:'
+    fieldType: text
+    fieldName: company_name
+    labelPosition: left
+    labelWidth: 150
+    width: 318
+
+  - type: field
+    label: 'Industry:'
+    fieldType: dropdown
+    fieldName: industry
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: financial, label: 'Financial Services'}
+      - {value: healthcare, label: 'Healthcare'}
+      - {value: government, label: 'Government'}
+      - {value: ecommerce, label: 'E-commerce/Retail'}
+      - {value: technology, label: 'Technology/SaaS'}
+      - {value: gaming, label: 'Gaming'}
+      - {value: media, label: 'Media/Entertainment'}
+      - {value: education, label: 'Education'}
+      - {value: manufacturing, label: 'Manufacturing'}
+      - {value: other, label: 'Other'}
+
+  - type: field
+    label: 'Compliance Requirements:'
+    fieldType: dropdown
+    fieldName: compliance
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: none, label: 'None specific'}
+      - {value: pci_dss, label: 'PCI-DSS'}
+      - {value: hipaa, label: 'HIPAA'}
+      - {value: fedramp, label: 'FedRAMP'}
+      - {value: soc2, label: 'SOC 2'}
+      - {value: gdpr, label: 'GDPR'}
+      - {value: multiple, label: 'Multiple'}
+
+  - type: field
+    label: 'Implementation Timeline:'
+    fieldType: dropdown
+    fieldName: timeline
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: urgent, label: 'Urgent'}
+      - {value: week, label: 'Within 1 week'}
+      - {value: month, label: 'Within 1 month'}
+      - {value: planning, label: 'Planning phase (3+ months)'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 2: Load Balancer Requirements Overview
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Load Balancer Requirements Overview'
+
+  - type: table
+    label: 'Load Balancer Types Needed'
+    columns:
+      - {label: 'Load Balancer Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['HTTP/HTTPS Load Balancers', 'lb_type_http']
+      - values: ['TCP Load Balancers', 'lb_type_tcp']
+      - values: ['UDP Load Balancers', 'lb_type_udp']
+
+  - type: table
+    label: 'Application Inventory'
+    fieldPrefix: app_inv
+    rowCount: 4
+    columns:
+      - label: 'Environment'
+        width: 120
+        cellType: dropdown
+        fieldSuffix: env
+        options:
+          - {value: prod, label: 'Production'}
+          - {value: staging, label: 'Staging'}
+          - {value: dev, label: 'Development'}
+          - {value: dr, label: 'Disaster Recovery'}
+      - {label: 'HTTP LB Count', width: 90, cellType: text, fieldSuffix: http_count}
+      - {label: 'TCP LB Count', width: 90, cellType: text, fieldSuffix: tcp_count}
+      - {label: 'UDP LB Count', width: 90, cellType: text, fieldSuffix: udp_count}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 3: HTTP/HTTPS Load Balancer Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'HTTP/HTTPS Load Balancer Configuration'
+
+  - type: table
+    label: 'HTTP Load Balancer Details'
+    fieldPrefix: http_lb
+    rowCount: 5
+    columns:
+      - {label: 'Application Name', width: 120, cellType: text, fieldSuffix: app_name}
+      - {label: 'Domain(s)', width: 140, cellType: text, fieldSuffix: domains}
+      - {label: 'Port(s)', width: 60, cellType: text, fieldSuffix: ports}
+      - label: 'Protocol'
+        width: 100
+        cellType: dropdown
+        fieldSuffix: protocol
+        options:
+          - {value: http, label: 'HTTP'}
+          - {value: https, label: 'HTTPS'}
+          - {value: both, label: 'Both'}
+
+  - type: field
+    label: 'TLS Certificate Management:'
+    fieldType: dropdown
+    fieldName: tls_cert_mgmt
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: automatic, label: "Automatic (Let's Encrypt)"}
+      - {value: custom, label: 'Custom certificates'}
+      - {value: mixed, label: 'Mixed'}
+
+  - type: field
+    label: 'TLS Security Level:'
+    fieldType: dropdown
+    fieldName: http_tls_security
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: high, label: 'High (TLS 1.2+ PFS)'}
+      - {value: medium, label: 'Medium (TLS 1.0+ PFS)'}
+      - {value: low, label: 'Low'}
+      - {value: custom, label: 'Custom'}
+
+  - type: field
+    label: 'mTLS Required:'
+    fieldType: dropdown
+    fieldName: mtls_required
+    labelPosition: left
+    labelWidth: 180
+    width: 250
+    options:
+      - {value: yes, label: 'Yes - Client certificates required'}
+      - {value: no, label: 'No'}
+
+  - type: table
+    label: 'HTTP Routing Requirements'
+    columns:
+      - {label: 'Routing Feature', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Path-based routing', 'route_path']
+      - values: ['Header-based routing', 'route_header']
+      - values: ['Query parameter routing', 'route_query']
+      - values: ['Method-based routing (GET/POST/etc.)', 'route_method']
+      - values: ['URL rewriting', 'route_rewrite']
+      - values: ['Redirects', 'route_redirect']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 4: TCP Load Balancer Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'TCP Load Balancer Configuration'
+
+  - type: table
+    label: 'TCP Load Balancer Details'
+    fieldPrefix: tcp_lb
+    rowCount: 5
+    columns:
+      - {label: 'Application Name', width: 110, cellType: text, fieldSuffix: app_name}
+      - label: 'Protocol'
+        width: 110
+        cellType: dropdown
+        fieldSuffix: protocol
+        options:
+          - {value: tcp, label: 'TCP'}
+          - {value: tls_tcp, label: 'TLS over TCP'}
+      - {label: 'Port(s)', width: 60, cellType: text, fieldSuffix: ports}
+      - label: 'Use Case'
+        width: 120
+        cellType: dropdown
+        fieldSuffix: use_case
+        options:
+          - {value: database, label: 'Database'}
+          - {value: gaming, label: 'Gaming'}
+          - {value: mail, label: 'Mail/SMTP'}
+          - {value: ssh, label: 'SSH/SFTP'}
+          - {value: custom, label: 'Custom Protocol'}
+
+  - type: field
+    label: 'TLS Configuration:'
+    fieldType: dropdown
+    fieldName: tcp_tls_config
+    labelPosition: left
+    labelWidth: 150
+    width: 250
+    options:
+      - {value: none, label: 'No TLS'}
+      - {value: auto, label: 'TLS with Auto Certificate'}
+      - {value: custom, label: 'TLS with Custom Certificate'}
+
+  - type: field
+    label: 'TLS Security Level:'
+    fieldType: dropdown
+    fieldName: tcp_tls_security
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: high, label: 'High (TLS 1.2+ PFS)'}
+      - {value: medium, label: 'Medium (TLS 1.0+ PFS)'}
+      - {value: low, label: 'Low'}
+      - {value: custom, label: 'Custom'}
+
+  - type: field
+    label: 'SNI Support:'
+    fieldType: dropdown
+    fieldName: tcp_sni_support
+    labelPosition: left
+    labelWidth: 150
+    width: 100
+    options:
+      - {value: yes, label: 'Yes'}
+      - {value: no, label: 'No'}
+
+  - type: paragraph
+    text: >
+      Note: FTPS and ALG protocols are not supported with TLS termination on TCP load balancers.
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 5: UDP Load Balancer Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'UDP Load Balancer Configuration'
+
+  - type: table
+    label: 'UDP Load Balancer Details'
+    fieldPrefix: udp_lb
+    rowCount: 5
+    columns:
+      - {label: 'Application Name', width: 140, cellType: text, fieldSuffix: app_name}
+      - {label: 'Port(s)', width: 80, cellType: text, fieldSuffix: ports}
+      - label: 'Use Case'
+        width: 150
+        cellType: dropdown
+        fieldSuffix: use_case
+        options:
+          - {value: gaming, label: 'Gaming/Real-time'}
+          - {value: voip, label: 'VoIP/SIP'}
+          - {value: dns, label: 'DNS'}
+          - {value: syslog, label: 'Syslog'}
+          - {value: custom, label: 'Custom'}
+
+  - type: field
+    label: 'Per-Packet Load Balancing:'
+    fieldType: dropdown
+    fieldName: udp_per_packet
+    labelPosition: left
+    labelWidth: 200
+    width: 268
+    options:
+      - {value: no, label: 'No (first packet determines upstream)'}
+      - {value: yes, label: 'Yes'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 6: Origin Pool Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Origin Pool Configuration'
+
+  - type: table
+    label: 'Origin Server Types'
+    columns:
+      - {label: 'Origin Server Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Public IP addresses', 'origin_public_ip']
+      - values: ['DNS/FQDN', 'origin_dns']
+      - values: ['Kubernetes Services', 'origin_k8s']
+
+  - type: field
+    label: 'Origin Connectivity:'
+    fieldType: dropdown
+    fieldName: origin_connectivity
+    labelPosition: left
+    labelWidth: 150
+    width: 250
+    options:
+      - {value: public, label: 'Public Internet'}
+      - {value: ce, label: 'Customer Edge (CE)'}
+      - {value: cloud, label: 'Cloud Site (AWS/Azure/GCP)'}
+      - {value: private_link, label: 'Private Link'}
+
+  - type: table
+    label: 'Origin Protocol Configuration'
+    fieldPrefix: origin_proto
+    rowCount: 5
+    columns:
+      - {label: 'Application', width: 150, cellType: text, fieldSuffix: app}
+      - label: 'Origin Protocol'
+        width: 140
+        cellType: dropdown
+        fieldSuffix: protocol
+        options:
+          - {value: http, label: 'HTTP'}
+          - {value: https, label: 'HTTPS'}
+          - {value: tcp, label: 'TCP'}
+          - {value: tls, label: 'TLS'}
+          - {value: udp, label: 'UDP'}
+      - {label: 'Origin Port', width: 80, cellType: text, fieldSuffix: port}
+
+  - type: table
+    label: 'Origin Server Count'
+    fieldPrefix: origin_count
+    rowCount: 5
+    columns:
+      - {label: 'Application', width: 130, cellType: text, fieldSuffix: app}
+      - {label: 'Primary Servers', width: 90, cellType: text, fieldSuffix: primary}
+      - {label: 'Secondary Servers', width: 95, cellType: text, fieldSuffix: secondary}
+      - {label: 'Location', width: 100, cellType: text, fieldSuffix: location}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 7: Load Balancing Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Load Balancing Configuration'
+
+  - type: field
+    label: 'HTTP LB Algorithm:'
+    fieldType: dropdown
+    fieldName: http_lb_algorithm
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: round_robin, label: 'Round Robin'}
+      - {value: least_request, label: 'Weighted Least Request'}
+      - {value: random, label: 'Random'}
+      - {value: ring_hash, label: 'Source IP Hash (Ring Hash)'}
+
+  - type: field
+    label: 'TCP LB Algorithm:'
+    fieldType: dropdown
+    fieldName: tcp_lb_algorithm
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: round_robin, label: 'Round Robin'}
+      - {value: least_active, label: 'Least Active Connections'}
+      - {value: random, label: 'Random'}
+      - {value: source_ip, label: 'Source IP Stickiness'}
+
+  - type: field
+    label: 'UDP LB Algorithm:'
+    fieldType: dropdown
+    fieldName: udp_lb_algorithm
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: round_robin, label: 'Round Robin'}
+      - {value: random, label: 'Random'}
+      - {value: source_ip, label: 'Source IP Stickiness'}
+
+  - type: field
+    label: 'Session Persistence:'
+    fieldType: dropdown
+    fieldName: session_persistence
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: source_ip, label: 'Yes - Source IP'}
+      - {value: cookie, label: 'Yes - Cookie (HTTP only)'}
+      - {value: none, label: 'No'}
+
+  - type: field
+    label: 'Persistence Timeout (sec):'
+    fieldType: text
+    fieldName: persistence_timeout
+    labelPosition: left
+    labelWidth: 180
+    width: 100
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 8: Health Check Configuration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Health Check Configuration'
+
+  - type: table
+    label: 'Health Check Details'
+    fieldPrefix: health
+    rowCount: 5
+    columns:
+      - {label: 'Application', width: 100, cellType: text, fieldSuffix: app}
+      - label: 'Check Type'
+        width: 90
+        cellType: dropdown
+        fieldSuffix: type
+        options:
+          - {value: http, label: 'HTTP'}
+          - {value: https, label: 'HTTPS'}
+          - {value: tcp, label: 'TCP'}
+          - {value: udp, label: 'UDP'}
+          - {value: icmp, label: 'ICMP'}
+      - {label: 'Port', width: 50, cellType: text, fieldSuffix: port}
+      - {label: 'Path (HTTP)', width: 90, cellType: text, fieldSuffix: path}
+      - {label: 'Interval (sec)', width: 80, cellType: text, fieldSuffix: interval}
+
+  - type: table
+    label: 'Health Check Thresholds'
+    columns:
+      - {label: 'Threshold', width: 240, cellType: label}
+      - {label: 'Value', width: 100, cellType: text}
+    rows:
+      - values: ['Healthy threshold (checks)', 'health_threshold_healthy']
+      - values: ['Unhealthy threshold (checks)', 'health_threshold_unhealthy']
+      - values: ['Timeout (seconds)', 'health_threshold_timeout']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 9: Traffic Volume
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Traffic Volume'
+
+  - type: table
+    label: 'Request/Connection Metrics'
+    columns:
+      - {label: 'Metric', width: 240, cellType: label}
+      - {label: 'Average', width: 70, cellType: text}
+      - {label: 'Peak', width: 70, cellType: text}
+    rows:
+      - values: ['Requests per second (HTTP)', 'traffic_rps_avg', 'traffic_rps_peak']
+      - values: ['Connections per second (TCP/UDP)', 'traffic_cps_avg', 'traffic_cps_peak']
+      - values: ['Concurrent connections', 'traffic_concurrent_avg', 'traffic_concurrent_peak']
+      - values: ['Bandwidth (Mbps)', 'traffic_bandwidth_avg', 'traffic_bandwidth_peak']
+
+  - type: table
+    label: 'Traffic Patterns'
+    columns:
+      - {label: 'Traffic Pattern', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Steady', 'pattern_steady']
+      - values: ['Business hours peaks', 'pattern_business_hours']
+      - values: ['Seasonal peaks', 'pattern_seasonal']
+      - values: ['Event-driven spikes', 'pattern_event_driven']
+      - values: ['Unpredictable', 'pattern_unpredictable']
+
+  - type: table
+    label: 'Geographic Distribution'
+    columns:
+      - {label: 'Region', width: 200, cellType: label}
+      - {label: 'Percentage (%)', width: 100, cellType: text}
+    rows:
+      - values: ['North America', 'geo_na']
+      - values: ['Europe', 'geo_eu']
+      - values: ['Asia-Pacific', 'geo_apac']
+      - values: ['South America', 'geo_sa']
+      - values: ['Other', 'geo_other']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 10: High Availability
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'High Availability'
+
+  - type: field
+    label: 'Multi-Region Deployment:'
+    fieldType: dropdown
+    fieldName: multi_region
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: active_active, label: 'Yes - Active/Active'}
+      - {value: active_standby, label: 'Yes - Active/Standby'}
+      - {value: single, label: 'No - Single region'}
+
+  - type: table
+    label: 'Regions Required'
+    columns:
+      - {label: 'Region', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['North America', 'region_na']
+      - values: ['Europe', 'region_eu']
+      - values: ['Asia-Pacific', 'region_apac']
+      - values: ['South America', 'region_sa']
+
+  - type: field
+    label: 'Origin Pool Failover:'
+    fieldType: dropdown
+    fieldName: origin_failover
+    labelPosition: left
+    labelWidth: 180
+    width: 200
+    options:
+      - {value: auto, label: 'Yes - Automatic failover'}
+      - {value: single, label: 'No - Single pool'}
+
+  - type: table
+    label: 'Failover Configuration'
+    fieldPrefix: failover
+    rowCount: 4
+    columns:
+      - {label: 'Primary Pool', width: 150, cellType: text, fieldSuffix: primary}
+      - {label: 'Secondary Pool', width: 150, cellType: text, fieldSuffix: secondary}
+      - label: 'Failover Condition'
+        width: 120
+        cellType: dropdown
+        fieldSuffix: condition
+        options:
+          - {value: health, label: 'Health check'}
+          - {value: manual, label: 'Manual'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 11: Security Integration
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Security Integration'
+
+  - type: paragraph
+    text: >
+      Security features apply primarily to HTTP/HTTPS load balancers.
+
+  - type: field
+    label: 'WAF Integration:'
+    fieldType: dropdown
+    fieldName: waf_integration
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: yes, label: 'Yes - Apply WAF policy'}
+      - {value: no, label: 'No'}
+
+  - type: field
+    label: 'Bot Defense:'
+    fieldType: dropdown
+    fieldName: bot_defense
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: yes, label: 'Yes - Enable bot defense'}
+      - {value: no, label: 'No'}
+
+  - type: field
+    label: 'API Protection:'
+    fieldType: dropdown
+    fieldName: api_protection
+    labelPosition: left
+    labelWidth: 150
+    width: 200
+    options:
+      - {value: openapi, label: 'Yes - OpenAPI validation'}
+      - {value: jwt, label: 'Yes - JWT validation'}
+      - {value: no, label: 'No'}
+
+  - type: table
+    label: 'Service Policies'
+    columns:
+      - {label: 'Policy Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['IP allowlist/denylist', 'policy_ip_list']
+      - values: ['Geo-blocking', 'policy_geo_block']
+      - values: ['Rate limiting', 'policy_rate_limit']
+      - values: ['Custom rules', 'policy_custom']
+
+  - type: field
+    label: 'Service Policy Rules Count:'
+    fieldType: text
+    fieldName: policy_rules_count
+    labelPosition: left
+    labelWidth: 200
+    width: 100
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 12: Timeouts and Limits
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Timeouts and Limits'
+
+  - type: table
+    label: 'Timeout Configuration'
+    columns:
+      - {label: 'Parameter', width: 240, cellType: label}
+      - {label: 'Value (sec)', width: 100, cellType: text}
+    rows:
+      - values: ['Request timeout', 'timeout_request']
+      - values: ['Idle timeout', 'timeout_idle']
+      - values: ['Connection timeout', 'timeout_connection']
+
+  - type: table
+    label: 'Connection Limits'
+    columns:
+      - {label: 'Limit', width: 240, cellType: label}
+      - {label: 'Value', width: 100, cellType: text}
+    rows:
+      - values: ['Max connections per client IP', 'limit_per_ip']
+      - values: ['Max total connections', 'limit_total']
+      - values: ['Max request body size (MB)', 'limit_body_size']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 13: Existing Load Balancing Solutions
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Existing Load Balancing Solutions'
+
+  - type: table
+    label: 'Existing Cloud LB Providers'
+    fieldPrefix: existing_cloud
+    rowCount: 4
+    columns:
+      - label: 'Provider'
+        width: 240
+        cellType: dropdown
+        fieldSuffix: provider
+        options:
+          - {value: aws_alb, label: 'AWS ALB'}
+          - {value: aws_nlb, label: 'AWS NLB'}
+          - {value: aws_clb, label: 'AWS CLB'}
+          - {value: azure_lb, label: 'Azure Load Balancer'}
+          - {value: azure_appgw, label: 'Azure Application Gateway'}
+          - {value: gcp_lb, label: 'Google Cloud Load Balancing'}
+          - {value: cloudflare, label: 'Cloudflare Load Balancing'}
+          - {value: akamai, label: 'Akamai GTM/ALB'}
+          - {value: fastly, label: 'Fastly Load Balancing'}
+          - {value: digitalocean, label: 'DigitalOcean Load Balancer'}
+          - {value: other, label: 'Other'}
+          - {value: none, label: 'None'}
+      - label: 'Action'
+        width: 100
+        cellType: dropdown
+        fieldSuffix: action
+        options:
+          - {value: replace, label: 'Replace'}
+          - {value: layer, label: 'Layer'}
+          - {value: keep, label: 'Keep'}
+
+  - type: table
+    label: 'Existing Hardware LB Providers'
+    fieldPrefix: existing_hw
+    rowCount: 4
+    columns:
+      - label: 'Provider'
+        width: 240
+        cellType: dropdown
+        fieldSuffix: provider
+        options:
+          - {value: f5_bigip, label: 'F5 BIG-IP'}
+          - {value: citrix, label: 'Citrix ADC (NetScaler)'}
+          - {value: a10, label: 'A10 Networks'}
+          - {value: haproxy, label: 'HAProxy'}
+          - {value: nginx_plus, label: 'NGINX Plus'}
+          - {value: kemp, label: 'Kemp LoadMaster'}
+          - {value: barracuda, label: 'Barracuda'}
+          - {value: radware, label: 'Radware Alteon'}
+          - {value: other, label: 'Other'}
+          - {value: none, label: 'None'}
+      - label: 'Action'
+        width: 100
+        cellType: dropdown
+        fieldSuffix: action
+        options:
+          - {value: replace, label: 'Replace'}
+          - {value: layer, label: 'Layer'}
+          - {value: keep, label: 'Keep'}
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 14: Operations & Support
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Operations & Support'
+
+  - type: table
+    label: 'Observability - Logging'
+    columns:
+      - {label: 'Log Type', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Access logs', 'log_access']
+      - values: ['Security event logs', 'log_security']
+      - values: ['Error logs', 'log_error']
+      - values: ['Custom log format', 'log_custom']
+
+  - type: table
+    label: 'Log Destinations'
+    columns:
+      - {label: 'Destination', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['F5 XC Console', 'dest_f5xc']
+      - values: ['External SIEM', 'dest_siem']
+      - values: ['Cloud storage (S3/etc.)', 'dest_cloud_storage']
+
+  - type: table
+    label: 'Metrics Required'
+    columns:
+      - {label: 'Metric', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Request rate', 'metric_request_rate']
+      - values: ['Response time/latency', 'metric_latency']
+      - values: ['Error rates', 'metric_errors']
+      - values: ['Origin health', 'metric_origin_health']
+      - values: ['Bandwidth', 'metric_bandwidth']
+
+  - type: field
+    label: 'Support Level:'
+    fieldType: dropdown
+    fieldName: support_level
+    labelPosition: left
+    labelWidth: 100
+    width: 240
+    options:
+      - {value: standard, label: 'Standard - Business hours'}
+      - {value: enhanced, label: 'Enhanced - 24x7 SOC'}
+      - {value: enhanced_plus, label: 'Enhanced Plus - Dedicated SOC'}
+
+  - type: table
+    label: 'Alert Methods'
+    columns:
+      - {label: 'Method', width: 290, cellType: label}
+      - {label: 'Select', width: 50, cellType: checkbox}
+    rows:
+      - values: ['Email', 'alert_email']
+      - values: ['Webhook/API', 'alert_webhook']
+      - values: ['SMS', 'alert_sms']
+      - values: ['SIEM integration', 'alert_siem']
+      - values: ['Phone (24x7 SOC)', 'alert_phone']
+
+  - type: table
+    label: '24/7 Emergency Contacts'
+    columns:
+      - {label: 'Contact', width: 88, cellType: label}
+      - {label: 'Name', width: 120, cellType: text}
+      - {label: 'Email', width: 150, cellType: text}
+      - {label: 'Phone', width: 110, cellType: text}
+    rows:
+      - values: ['Primary', 'contact_primary_name', 'contact_primary_email', 'contact_primary_phone']
+      - values: ['Secondary', 'contact_secondary_name', 'contact_secondary_email', 'contact_secondary_phone']
+      - values: ['Escalation', 'contact_escalation_name', 'contact_escalation_email', 'contact_escalation_phone']
+
+  - type: rule
+
+  # ============================================================================
+  # SECTION 15: Additional Notes
+  # ============================================================================
+  - type: heading
+    level: 2
+    text: 'Additional Notes'
+
+  - type: field
+    label: 'Additional Notes:'
+    labelPosition: above
+    fieldType: textarea
+    fieldName: additional_notes
+    width: 468
+    height: 120
+
+fields: []


### PR DESCRIPTION
Closes #33

## Summary
Add comprehensive YAML schemas for F5 Distributed Cloud assessment forms:
- **dns-services.yaml**: Complete DNS Services assessment form (629 lines)
- **load-balancers.yaml**: Complete Load Balancer assessment form (838 lines)

## Changes
- Added DNS Services schema with 12 sections covering organization profile, DNS service types, zone configuration, GSLB, health checking, security, zone management, query volume, advanced features, existing providers, and operations/support
- Added Load Balancer schema with 15 sections covering HTTP/HTTPS, TCP, and UDP load balancing, origin pools, health checks, traffic volume, high availability, security integration, timeouts/limits, and operations/support
- Both schemas follow existing YAML conventions and pass pre-commit hooks

## Testing
- All 375 tests pass
- Pre-commit validation: All hooks pass (yamllint, prettier, trailing whitespace, merge conflict checks)
- No security audit issues