### PR TITLE
fix: split release workflow for full automation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Create GitHub Release
 
 on:
   push:
@@ -7,28 +7,12 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test:run
-
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
 
       - name: GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.release-it.json
+++ b/.release-it.json
@@ -9,11 +9,7 @@
     "pushArgs": ["--follow-tags"]
   },
   "github": {
-    "release": true,
-    "releaseName": "v${version}",
-    "draft": false,
-    "preRelease": false,
-    "tokenRef": "GITHUB_TOKEN"
+    "release": false
   },
   "npm": {
     "publish": true,


### PR DESCRIPTION
## Summary
- Disable GitHub release in release-it (plugin has a bug)
- Let publish.yaml create GitHub release on tag push via softprops/action-gh-release
- Remove duplicate npm publish from publish.yaml (release-it handles it)

## Workflow
1. `release.yaml` (manual trigger): version bump → changelog → npm publish → git tag/push
2. `publish.yaml` (tag trigger): creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)