### PR TITLE
fix: always release minor on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,10 +59,9 @@ jobs:
             exit 0
           fi
           echo "Latest tag: $LATEST_TAG"
-          RELEASABLE=$(git log ${LATEST_TAG}..HEAD --format="%s" --no-merges | grep -cE "^(feat|fix|perf)(\(.+\))?(!)?:" || true)
-          BREAKING=$(git log ${LATEST_TAG}..HEAD --format="%b" --no-merges | grep -c "BREAKING CHANGE:" || true)
-          echo "Releasable commits: $RELEASABLE, Breaking changes: $BREAKING"
-          if [ "$RELEASABLE" -gt 0 ] || [ "$BREAKING" -gt 0 ]; then
+          COMMIT_COUNT=$(git log ${LATEST_TAG}..HEAD --format="%s" --no-merges | wc -l | tr -d ' ')
+          echo "New commits since $LATEST_TAG: $COMMIT_COUNT"
+          if [ "$COMMIT_COUNT" -gt 0 ]; then
             echo "should_release=true" >> $GITHUB_OUTPUT
           else
             echo "No releasable commits found since $LATEST_TAG"
@@ -77,7 +76,7 @@ jobs:
             echo "version_arg=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             echo "should_release=${{ steps.check.outputs.should_release }}" >> $GITHUB_OUTPUT
-            echo "version_arg=" >> $GITHUB_OUTPUT
+            echo "version_arg=minor" >> $GITHUB_OUTPUT
           fi
 
       - name: Build


### PR DESCRIPTION
## Summary
- Remove conventional commit prefix requirement from release workflow
- Every push to main now triggers a minor version bump automatically
- `workflow_dispatch` with explicit version choice (patch/minor/major) still works as override

## Test plan
- [ ] Push any commit (e.g. "update readme") to main — should trigger a minor release
- [ ] Bot commits (`chore: release v*`, `chore: rebuild action bundle`, `[skip ci]`) still skipped
- [ ] `workflow_dispatch` with explicit version choice still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)