### PR TITLE
feat: improve footer layout positioning

### DIFF
--- a/src/generators/html/layout.ts
+++ b/src/generators/html/layout.ts
@@ -66,10 +66,12 @@ export function initializeHtmlLayout(pageSize: HtmlPageSize = 'a4'): HtmlLayoutC
   const pageDimensions =
     pageSize === 'a4' ? components.pageLayout.a4 : components.pageLayout.letter;
 
-  // Content height = page height - top margin - bottom margin
+  // Content height = page height - top margin - bottom margin - footer reserve
   // This matches PDF: pageSize.height - margins.top - margins.bottom
   // Page number is absolutely positioned, so doesn't affect content area
-  const contentHeight = pageDimensions.height - pageDimensions.margin * 2;
+  // Reserve space for footer (text + separator + social icons)
+  const footerReserve = 50;
+  const contentHeight = pageDimensions.height - pageDimensions.margin * 2 - footerReserve;
 
   return {
     pageSize,

--- a/src/styles/html-adapter.ts
+++ b/src/styles/html-adapter.ts
@@ -59,6 +59,7 @@ export function generateCssFromTokens(pageLayout?: PageLayoutConfig): string {
 
     .page {
       width: ${pageDimensions.width}px;
+      height: ${pageDimensions.height}px;
       min-height: ${pageDimensions.height}px;
       background: ${components.pageLayout.pageBackgroundColor};
       box-shadow: ${components.pageLayout.pageShadow};
@@ -70,6 +71,13 @@ export function generateCssFromTokens(pageLayout?: PageLayoutConfig): string {
     .page-content {
       width: ${pageDimensions.contentWidth}px;
       max-width: 100%;
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+    }
+
+    .page-content > main {
+      flex: 1 1 auto;
     }
 
     .page-number {
@@ -255,7 +263,7 @@ export function generateCssFromTokens(pageLayout?: PageLayoutConfig): string {
     }
 
     footer {
-      margin-top: ${rem(spacing[6])};
+      margin-top: auto;
       padding-top: ${rem(spacing[3])};
       text-align: center;
       color: ${colors.gray[500]};
@@ -263,7 +271,7 @@ export function generateCssFromTokens(pageLayout?: PageLayoutConfig): string {
     }
 
     .document-footer {
-      margin-top: ${rem(spacing[6])};
+      margin-top: auto;
       padding-top: ${rem(spacing[3])};
       color: ${colors.gray[500]};
       font-size: ${rem(components.footer.fontSize)};


### PR DESCRIPTION
Closes #68

Improve footer layout to properly position at bottom of page with reserved space.

**Changes:**
- Add footer reserve space (50px) to content height calculation in layout initialization
- Implement flexbox layout for .page-content to push footer to bottom
- Update footer margin-top from static spacing to auto for proper alignment

**Testing:**
- All existing tests pass (374 passed, 5 skipped)
- Type checking passes
- Lint and formatting checks pass